### PR TITLE
chore: Updated react peer dependency to 17.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "window-or-global": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.0",


### PR DESCRIPTION
React got an update in March 2021. If you update it in your project which uses react-twitch-embed-video, you get dependency conflicts. I updated the react peer dependency to be able to use the newest version of react.